### PR TITLE
refactor: 避免中划线加大写的自定义组建命名转换成非法的 js 变量名

### DIFF
--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -264,7 +264,7 @@ function toCamel (str) {
  * 驼峰命名转为短横线命名
  */
 function getKebabCase (str) {
-    return str.replace(/[A-Z]/g, function (i) {
+    return str.replace(/(?<!\-)[A-Z]/g, function (i) {
         return '-' + i.toLowerCase()
     })
 }


### PR DESCRIPTION
如 list-Item -> listItem 而不是 list-Item